### PR TITLE
kirkstone + gst-plugin-pylon

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,6 +8,6 @@ BBFILE_COLLECTIONS += "basler-common"
 BBFILE_PATTERN_basler-common = "^${LAYERDIR}/"
 BBFILE_PRIORITY_basler-common = "50"
 LAYERVERSION_basler-common = "2"
-LAYERSERIES_COMPAT_basler-common = "hardknott honister"
+LAYERSERIES_COMPAT_basler-common = "kirkstone"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"

--- a/recipes-camera/gst-plugin-pylon/gst-plugin-pylon_0.5.1.bb
+++ b/recipes-camera/gst-plugin-pylon/gst-plugin-pylon_0.5.1.bb
@@ -1,0 +1,30 @@
+SUMMARY = "The official GStreamer plug-in for Basler cameras"
+DESCRIPTION = "This plugin allows to use any Basler 2D camera (supported by Basler pylon Camera Software Suite) as source element in a GStreamer pipeline."
+HOMEPAGE = "https://github.com/basler/gst-plugin-pylon"
+LICENSE = "BSD-3-Clause"
+
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base pylon cmake-native"
+
+inherit pkgconfig meson
+
+SRC_URI = "git://github.com/basler/gst-plugin-pylon.git;branch=main;name=git;protocol=https"
+SRCREV_git = "ac4e0c29314109b1ffd97039a8a5167225fe2239"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=ae3b821cf6c4b42fabeceeafd1df5f95"
+
+# basler build configuration
+export PYLON_ROOT="${WORKDIR}/recipe-sysroot/opt/pylon"
+
+S = "${WORKDIR}/git"
+
+FILES:${PN} += "/usr/lib/gstreamer-1.0/libgstpylon.so"
+
+do_configure:prepend() {
+    # (dirty) workaround: meson uses cmake to find the pylon stuff, however
+    # meson.cross file is not aware of the cmake binary, therefore add it
+    sed -i "/\[binaries\]/a cmake = 'cmake'" "${WORKDIR}/meson.cross"
+}
+
+# QA Issue: gst-plugin-pylon rdepends on gst-plugin-pylon-dev [dev-deps]
+# QA Issue: -dev package gst-plugin-pylon-dev contains non-symlink .so '/usr/lib/libgstpylon-1.0.so' [dev-elf]
+INSANE_SKIP:${PN} = "dev-deps"
+INSANE_SKIP:${PN}-dev = "dev-elf"


### PR DESCRIPTION
Hi!

This PR is targeted for a "kirkstone" branch and adds gst-plugin-pylon support.

Unfortunately, I had to implement a quite dirty workaround to get it running, because the meson toolchain in Yocto currently does not support the dependency via cmake method as [required by the plugin](https://github.com/basler/gst-plugin-pylon/blob/main/gst-libs/gst/pylon/meson.build#L14).

Still wanted to share, because together with https://github.com/basler/meta-basler-imx8/pull/7 it is working in my environment.

Best regards
Benjamin